### PR TITLE
Import .wem files in the same way as exporting .wav files with sequence number.

### DIFF
--- a/audio_modder.py
+++ b/audio_modder.py
@@ -1877,11 +1877,11 @@ class FileHandler:
             splits: list[str] = basename.split("_", 1)
             prefix, rest = splits[0], splits[1]
             has_seq: bool = True 
-            for i in range(0, 3):
+            for i in range(0, 2):
                 if not prefix[i].isdigit():
                     has_seq = False
                     break
-            has_seq = has_seq and prefix[3] == "_"
+            has_seq = has_seq and prefix[2] == "_"
             if has_seq:
                 basename = rest
             progress_window.set_text("Loading " + basename)

--- a/audio_modder.py
+++ b/audio_modder.py
@@ -1873,8 +1873,18 @@ class FileHandler:
                                          max_progress=len(wems))
         progress_window.show()
         for wem in wems:
-            progress_window.set_text("Loading " + os.path.basename(wem))
-            file_id: int | None = self.get_number_prefix(os.path.basename(wem))
+            basename = os.path.basename(wem)
+            splits: list[str] = basename.split("_", 1)
+            prefix, rest = splits[0], splits[1]
+            has_seq: bool = True 
+            for c in prefix:
+                if not c.isdigit():
+                    has_seq = False
+                    break
+            if has_seq:
+                basename = rest
+            progress_window.set_text("Loading " + basename)
+            file_id: int | None = self.get_number_prefix(basename)
             if file_id == None:
                 continue
             audio: str | None = self.get_audio_by_id(file_id)
@@ -1885,6 +1895,7 @@ class FileHandler:
             progress_window.step()
         progress_window.destroy()
       
+
 class ProgressWindow:
     def __init__(self, title, max_progress):
         self.title = title

--- a/audio_modder.py
+++ b/audio_modder.py
@@ -1877,10 +1877,11 @@ class FileHandler:
             splits: list[str] = basename.split("_", 1)
             prefix, rest = splits[0], splits[1]
             has_seq: bool = True 
-            for c in prefix:
-                if not c.isdigit():
+            for i in range(0, 3):
+                if not prefix[i].isdigit():
                     has_seq = False
                     break
+            has_seq = has_seq and prefix[3] == "_"
             if has_seq:
                 basename = rest
             progress_window.set_text("Loading " + basename)


### PR DESCRIPTION
I realized since it can export .wav files with sequence number, and people might directly edit and overwrite these .wav files, and then do the conversion in Wwise, without changing their filename, it make sense the modding tool to recognize the prefix sequence number, and strip them off directly. 
The current implementation is simply checking whether there's a prefix resemble a given specific format. It does not parse based on a format users provide, which specify how their filenames are formatted. However, that might be a separate feature.