### PR TITLE
Builtin Archive Search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ vgmstream-macos/
 __pycache__/
 **/*.pickle
 **/log.txt
+**/*.db

--- a/audio_modder.py
+++ b/audio_modder.py
@@ -2294,6 +2294,14 @@ class EventWindow:
         self.track_info.set_data(play_at=float(self.play_at_text_var.get()), begin_trim_offset=float(self.start_offset_text_var.get()), end_trim_offset=float(self.end_offset_text_var.get()), source_duration=float(self.duration_text_var.get()))
         self.update_modified()
 
+"""
+Not suggested to use this as a generic autocomplete widget for other searches.
+Currently it's only used specifically for search archive.
+
+This is not a truely autocomplete widget because it render a brand new top level 
+window that contains a Listbox every time the Entry widge is changed. Widget such 
+as Combobox, Spinbox, and similar widgets that are builtin internally in Tkinter.
+"""
 class ArchiveSearch(ttk.Entry):
 
     ignore_keys: list[str] = ["Up", "Down", "Left", "Right", "Escape", "Return"]
@@ -2804,13 +2812,14 @@ class MainWindow:
         categories = self.lookup_store.query_helldiver_audio_archive_category()
         categories = [""] + categories
         self.category_search = ttk.Combobox(self.top_bar,
-                                                font=('Segoe UI', 10),
-                                                width=18, height=10,
-                                                values=categories)
+                                            state="readonly",
+                                            font=('Segoe UI', 10),
+                                            width=18, height=10,
+                                            values=categories) 
         self.archive_search.pack(side="left", padx=4, pady=8)
         self.category_search.pack(side="left", padx=4, pady=8)
-        self.category_search.bind("<<ComboboxSelected>>", 
-                                      self.on_category_search_bar_select)
+        self.category_search.bind("<<ComboboxSelected>>",
+                                  self.on_category_search_bar_select)
 
     def on_archive_search_bar_return(self, value: str):
         splits = value.split(" || ")
@@ -2825,6 +2834,8 @@ class MainWindow:
         category: str = self.category_search.get()
         archives = self.lookup_store.query_helldiver_audio_archive(category)
         self.archive_search.set_entries(archives)
+        self.archive_search.focus_set()
+        self.category_search.selection_clear()
 
     def treeview_on_right_click(self, event):
         try:

--- a/audio_modder.py
+++ b/audio_modder.py
@@ -2645,6 +2645,14 @@ class MainWindow:
         self.search_bar.bind("<Return>", self.search_bar_on_enter_key)
 
         self.root.resizable(False, False)
+
+        # Reopen most recently loaded archives
+        if len(self.app_state.recent_files) > 0 and \
+                os.path.exists(self.app_state.recent_files[-1]):
+            self.root.after(500, 
+                            lambda: self.load_archive(
+                                archive_file=self.app_state.recent_files[-1])
+                           )
         self.root.mainloop()
         
     def search_bar_on_enter_key(self, event):

--- a/db.py
+++ b/db.py
@@ -1,0 +1,74 @@
+import sqlite3
+
+from logging import Logger
+from typing import Callable
+
+from log import logger
+
+def config_sqlite_conn(db_path: str):
+    conn: sqlite3.Connection | None = None
+
+    def _get_sqlite_conn() -> sqlite3.Connection | None:
+        nonlocal conn
+        if conn != None:
+            return conn
+        try:
+            conn = sqlite3.connect(db_path)
+        except Exception as err:
+            logger.error("Failed to connect helldiver audio source database")
+            conn = None
+        return conn
+
+    return _get_sqlite_conn
+
+
+"""
+Database Access Interface
+"""
+class LookupStore:
+
+    def query_helldiver_four_vo(self, query: str) -> dict[str, str]:
+        return {} 
+
+    def query_helldiver_audio_archive(self, category: str = "") -> dict[str, str]:
+        return {}
+
+    def query_helldiver_audio_archive_category(self) -> list[str]:
+        return []
+
+
+class SQLiteLookupStore (LookupStore):
+
+    def __init__(self, initializer: Callable[[], sqlite3.Connection | None], 
+                 logger: Logger):
+        self.conn = initializer()
+        if self.conn != None:
+            self.cursor = self.conn.cursor()
+        else:
+            logger.warning("Builtin audio source lookup is disabled due to database connection error")
+    
+    def query_helldiver_audio_archive(self, category: str = "") -> dict[str, str]:
+        rows: sqlite3.Cursor
+        if category == "":
+            rows = self.cursor.execute("SELECT archive_id, basename FROM helldiver_audio_archives")
+        else:
+            args = (category,)
+            rows = self.cursor.execute("SELECT archive_id, basename FROM helldiver_audio_archives WHERE category = ?", args)
+        return {row[0]: row[1] for row in rows}
+
+    def query_helldiver_audio_archive_category(self) -> list[str]:
+        rows = self.cursor.execute("SELECT DISTINCT category FROM helldiver_audio_archives")
+        return [row[0] for row in rows]
+
+    def query_helldiver_four_vo(self, query: str) -> dict[str, str]:
+        if len(query) == "":
+            return {}
+
+        if self.cursor == None:
+            return {}
+        # TO-DO the possibilities of verify SQL injection
+        args = (" OR ".join([f"\"{token}\"" for token in query.strip().split(" ") 
+                             if len(token) > 0]), )
+        rows = self.cursor.execute("SELECT file_id, transcription FROM helldiver_four_vo_fts WHERE transcription MATCH ? ORDER BY rank LIMIT 10", 
+                                   args)
+        return {row[0]: row[1] for row in rows} 

--- a/db.py
+++ b/db.py
@@ -12,11 +12,7 @@ def config_sqlite_conn(db_path: str):
         nonlocal conn
         if conn != None:
             return conn
-        try:
-            conn = sqlite3.connect(db_path)
-        except Exception as err:
-            logger.error("Failed to connect helldiver audio source database")
-            conn = None
+        conn = sqlite3.connect(db_path)
         return conn
 
     return _get_sqlite_conn


### PR DESCRIPTION
- I implemented a builtin archive search. The archive search is Entry with auto-complete and auto-suggestion (Read the remark for `ArchiveSearch` if you decided to use it for other searches). The implementation is fairly isolated all existence features since most of them are new. This archive search can be used as a widget for other searches but I wouldn't recommend it right now at the current stage.
- A database access layer is also included since all information is stored inside a SQLite3 database instead of other forms of text based files. The actual database and all logic relative to database migration and syncing with the spreadsheet are in a different [repo](https://github.com/Dekr0/hd2_audio_db). I include a pre-generated database I'm currently using in [here](https://github.com/Dekr0/hd2_audio_db/releases/download/v0.0.0-alpha/hd_audio_db.db). It should be up to date with the spreadsheet. The database (`hd_audio_db.db`) need to be in the same directory where `audio_modder.py` or the executable is in. Otherwise the builtin archive search functionality will be disabled by default.