### PR TITLE
Add options to revert partial patched audio sources / all audio sources in the bank

### DIFF
--- a/audio_modder.py
+++ b/audio_modder.py
@@ -2340,6 +2340,12 @@ class FileHandler:
             is_revert = "revert" in sub_spec and \
                     isinstance(sub_spec["revert"], bool) and \
                     sub_spec["revert"]
+            is_revert_all = "revert_all" in sub_spec and \
+                    isinstance(sub_spec["revert_all"], bool) and \
+                    sub_spec["revert_all"]
+            if is_revert_all:
+                self.revert_all()
+                continue
             if is_revert:
                 for wem in wems:
                     self.revert_audio(wem[2])


### PR DESCRIPTION
- The `revert` and `revert_all` directives mainly provide more control on the behaviour of importing wave files and writing patches.
- Here some use cases:
  - Generate multiple variants of a SFX mod where the patched audio sources of each variant are exclusive each other.
## Example 1
```json
{
	"v": 2,
	"specs": [
		{
			"workspace": "source_1",
			"mapping": {
				"transient_01": "169029097",
				"transient_02": "1015211601",
				"transient_03": "442290325",
				"transient_04": "898053678",
				"transient_05": "506455856"
			},
			"write_patch_to": "dest_1"
                        "revert": true
		}
	]
}
```
- This will revert the audio source of `872092613`, `947154282`, `81887028` and `10134064` back to vanilla audio after writing a patch to `dest_1`.
## Example 2
```json
{
	"v": 2,
	"specs": [
		{
			"workspace": "source_1",
			"mapping": {
				"transient_01": "169029097",
				"transient_02": "1015211601",
				"transient_03": "442290325",
				"transient_04": "898053678",
				"transient_05": "506455856"
			},
			"write_patch_to": "dest_1"
		},
		{
			"workspace": "source_2",
			"mapping": {
				"bolt_eject_round_01": "472775222",
				"bolt_eject_round_02": "942907321",
				"bolt_eject_round_03": "787517884",
				"bolt_eject_round_04": "710200241",
				"bolt_eject_round_05": "1029055137",
				"bolt_eject_round_06": "406717457"
			},
                       "write_patch_to": "dest_2",
                       "revert": true
		}
	],
}
```
- `169029097`, `1015211601`, `442290325`, `898053678` and `506455856` will retain after writing a patch to `dest_1`
-  After writing a patch to `dest_2`, it will revert `169029097`, `1015211601`, `442290325`, `898053678`, `506455856`, `472775222`, `942907321`, `787517884`, `710200241`, `1029055137` and `406717457`.
## Example 3
```json
{
	"v": 2,
	"specs": [
		{
			"workspace": "source_1",
			"mapping": {
				"transient_01": "169029097",
				"transient_02": "1015211601",
				"transient_03": "442290325",
				"transient_04": "898053678",
				"transient_05": "506455856"
			},
			"write_patch_to": "dest_1"
		}
	]
}
```
- `revert_all` will take a higher priority than `revert`, which will skip `revert` directly. `revert_all`will revert all audio sources back to the original audio data.