### PR TITLE
Sound parser update

### DIFF
--- a/env.py
+++ b/env.py
@@ -27,6 +27,8 @@ SYS_CLIPBOARD = ""
 WWISE_CLI = ""
 WWISE_VERSION = ""
 
+os.environ["TEST_FLAG"] = "False"
+
 match SYSTEM:
     case "Windows":
         FFMPEG = "ffmpeg.exe"

--- a/testbench.py
+++ b/testbench.py
@@ -1,0 +1,7 @@
+import unittest
+
+from tests.sound_parser_test import TestSoundParser
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/sound_parser_test.py
+++ b/tests/sound_parser_test.py
@@ -1,0 +1,83 @@
+import os
+import posixpath as xpath
+import unittest
+
+import env
+
+from core import GameArchive
+from log import logger
+from wwise_hierarchy import Sound, pack_sound
+
+
+class TestSoundParser(unittest.TestCase):
+
+    def test_robust(self):
+        files = os.scandir(env.get_data_path())
+
+        for file in files:
+            if not file.is_file():
+                continue
+            name, ext = os.path.splitext(file.path)
+            if ext != ".stream":
+                continue
+            logger.critical(f"Testing {os.path.basename(name)}")
+            left = GameArchive.from_file(name)
+            os.environ["TEST_FLAG"] = "True"
+            right = GameArchive.from_file(name)
+            os.environ["TEST_FLAG"] = "False"
+
+            left_sounds: dict[int, Sound] = {}
+            for v in left.wwise_banks.values():
+                if v.hierarchy == None:
+                    continue
+                left_sounds.update({
+                    k: v 
+                    for k, v in v.hierarchy.entries.items()
+                    if isinstance(v, Sound)
+                }) 
+            right_sounds: dict[int, Sound] = {}
+            for v in right.wwise_banks.values():
+                if v.hierarchy == None:
+                    continue
+                right_sounds.update({
+                    k: v 
+                    for k, v in v.hierarchy.entries.items()
+                    if isinstance(v, Sound)
+                }) 
+            for k, v in right_sounds.items():
+                self.assertTrue(k in left_sounds)
+                self.assertEqual(pack_sound(v), left_sounds[k].get_data())
+                    
+
+    def test_edge_case(self):
+        files = [
+            "04f60fc9a8eec97d",
+        ]
+        for file in files:
+            logger.critical(f"Testing {file}")
+            left = GameArchive.from_file(xpath.join(env.get_data_path(), file))
+            os.environ["TEST_FLAG"] = "True"
+            right = GameArchive.from_file(xpath.join(env.get_data_path(), file))
+            os.environ["TEST_FLAG"] = "False"
+
+            left_sounds: dict[int, Sound] = {}
+            for v in left.wwise_banks.values():
+                if v.hierarchy == None:
+                    continue
+                left_sounds.update({
+                    k: v 
+                    for k, v in v.hierarchy.entries.items()
+                    if isinstance(v, Sound)
+                }) 
+            right_sounds: dict[int, Sound] = {}
+            for v in right.wwise_banks.values():
+                if v.hierarchy == None:
+                    continue
+                right_sounds.update({
+                    k: v 
+                    for k, v in v.hierarchy.entries.items()
+                    if isinstance(v, Sound)
+                }) 
+            for k, v in right_sounds.items():
+                self.assertTrue(k in left_sounds)
+                self.assertEqual(pack_sound(v), left_sounds[k].get_data())

--- a/util.py
+++ b/util.py
@@ -105,6 +105,9 @@ class MemoryStream:
 
     def uint64_read(self):
         return self.read_format('Q', 8)
+
+    def float_read(self) -> float:
+        return self.read_format('f', 4)
         
 def pad_to_16_byte_align(data):
     b = bytearray(data)


### PR DESCRIPTION
- A updated version of parser for Sound object
- The implementation parser is based off wwiser implementation parser for Sound object under sound bank version of 141.
- I ran a brute force test on parser for every single archive in the `data` folder, and it doesn't seems to any error.
- Essentially what the test is doing:
  - Create two instances of GameArchive. This two archives will load the same file. 
  - The first instance of GameArchive will use the old parser to parse Sound object. 
  - The second instance of GameArchive will use the new parser to parse Sound object.
  - Each instance will collect all Sound object in a map.
  - The first instance will use each key of its map to locate its Sound object and the corresponding Sound object from map of the second instance.
  - The first instance GameArchive use the old packing logic to pack the content generated by the old parser. The second instance of GameArchive use the new packing logic to pack the content generated by the new parser.
  - Do a byte by byte comparison if there's any difference between two output.
- All new implementation are located at the bottom of `wwise_hierarchy.py`. The old implementation is still here since I need to use it do diff testing. You can replace the old parser and old logic with new version once you review it.