### PR TITLE
Bug fixing

### DIFF
--- a/audio_modder.py
+++ b/audio_modder.py
@@ -589,7 +589,7 @@ class MusicTrackWindow:
         clip_automations = copy.deepcopy(self.track.clip_automations)
         for index, tab in enumerate(self.graph_notebook.tabs()):
             graph = self.graph_notebook.nametowidget(tab)
-            x, y = self.graph.get_data()
+            x, y = graph.get_data()
             clip_automations[index].num_graph_points = len(x)
             clip_automations[index].graph_points = [(x[i], y[i], 4) for i in range(len(x))] #linear interpolation = 0x04
         self.track.set_data(track_info=tracks, clip_automations=clip_automations)
@@ -1503,7 +1503,7 @@ class MainWindow:
             archive = os.path.join(self.app_state.game_data_path, archive)
             self.task_manager.schedule(name=f"Loading Archive {os.path.basename(archive)}", callback=None, task=task(mod.load_archive_file), archive_file=archive)
         for file in files:
-            self.task_manager.schedule(name=f"Applying Patch {file}", callback=None, task=task(mod.import_patch), patch_file=file)
+            self.task_manager.schedule(name=f"Applying Patch {file}", callback=None, task=task(mod.import_patch), patch_file=file, import_hierarchy=False)
         self.task_manager.schedule(name="Saving Output File", callback=None, task=self.combine_mods_write_output, mod=mod)
         
     @task    
@@ -2480,7 +2480,7 @@ class MainWindow:
         for archive in archives:
             archive = os.path.join(self.app_state.game_data_path, archive)
             self.task_manager.schedule(name=f"Loading Archive {os.path.basename(archive)}", callback=self.import_patch_load_archive_finished, task=self.load_archive_task, archive_files=[archive])
-        self.task_manager.schedule(name="Applying Patch", callback=self.import_patch_finished, task=task(self.mod_handler.get_active_mod().import_patch), patch_file=patch_file)
+        self.task_manager.schedule(name="Applying Patch", callback=self.import_patch_finished, task=task(self.mod_handler.get_active_mod().import_patch), patch_file=patch_file, import_hierarchy=False)
         
     @callback
     def import_patch_load_archive_finished(self, results):

--- a/audio_modder.py
+++ b/audio_modder.py
@@ -1901,7 +1901,6 @@ class MainWindow:
                 )
 
                 tags = self.treeview.item(selects[-1], option="tags")
-                assert(len(tags) == 1)
                 self.right_click_id = int(tags[0])
                 
                 self.right_click_menu.add_command(

--- a/audio_modder.py
+++ b/audio_modder.py
@@ -1309,7 +1309,7 @@ class MainWindow:
         self.window.add(self.treeview_panel)
         self.window.add(self.entry_info_panel)
         
-        self.root.title("Helldivers 2 Audio Modder")
+        self.root.title(f"Helldivers 2 Audio Modder {VERSION}")
         self.root.geometry(f"{WINDOW_WIDTH}x{WINDOW_HEIGHT}")
         
         self.right_click_menu = Menu(self.treeview, tearoff=0)

--- a/audio_modder.py
+++ b/audio_modder.py
@@ -2530,8 +2530,8 @@ if __name__ == "__main__":
                     "Audio playback is disabled.")
                      
     if not os.path.exists(WWISE_CLI) and SYSTEM != "Linux":
-        logger.warning("Wwise installation not found. WAV file import is disabled.")
-        showwarning(title="Missing Plugin", message="Wwise installation not found. WAV file import is disabled.")
+        logger.warning("Wwise installation not found. The only file type available for import is WEM.")
+        showwarning(title="Missing Plugin", message="Wwise installation not found. The only file type available for import is WEM.")
     
     if os.path.exists(WWISE_CLI) and not os.path.exists(DEFAULT_WWISE_PROJECT):
         process = subprocess.run([

--- a/core.py
+++ b/core.py
@@ -1723,7 +1723,7 @@ class Mod:
                 self.audio_count[key] = 1
                 self.get_audio_sources()[key] = game_archive.audio_sources[key]
             
-    def import_patch(self, patch_file: str = ""):
+    def import_patch(self, patch_file: str = "", import_hierarchy=True):
         """
         @exception
         - OSError
@@ -1775,17 +1775,18 @@ class Mod:
                                 t.play_at = 0
                                 break
                         item.set_data(track_info=tracks)
-                            
-        for bank in patch_game_archive.get_wwise_banks().values():
-            if bank.hierarchy == None:
-                raise AssertionError(
-                    f"WwiseBank {bank.file_id} has no WwiseHierarchy"
-                )
-            try:
-                self.get_wwise_banks()[bank.get_id()].import_hierarchy(bank.hierarchy)
-            except Exception as e:
-                logger.error(e)
-                logger.warning(f"Unable to import heirarchy information for {bank.dep.data}")
+        
+        if import_hierarchy:
+            for bank in patch_game_archive.get_wwise_banks().values():
+                if bank.hierarchy == None:
+                    raise AssertionError(
+                        f"WwiseBank {bank.file_id} has no WwiseHierarchy"
+                    )
+                try:
+                    self.get_wwise_banks()[bank.get_id()].import_hierarchy(bank.hierarchy)
+                except Exception as e:
+                    logger.error(e)
+                    logger.warning(f"Unable to import heirarchy information for {bank.dep.data}")
 
         for text_bank in patch_game_archive.get_text_banks().values():
             try:

--- a/core.py
+++ b/core.py
@@ -1651,6 +1651,8 @@ class Mod:
                             existing_entry.size += 4
                 for bank in entry.soundbanks:
                     bank.hierarchy.entries[key] = existing_entry
+                    if existing_entry.modified:
+                        bank.raise_modified()
                     if bank not in existing_entry.soundbanks:
                         existing_entry.soundbanks.append(bank)
             else:
@@ -1717,7 +1719,8 @@ class Mod:
             if key in self.get_audio_sources().keys():
                 self.audio_count[key] += 1
                 for parent in game_archive.audio_sources[key].parents:
-                    self.get_audio_sources()[key].parents.add(parent)
+                    if parent.get_id() not in [p.get_id() for p in self.audio_sources[key].parents]:
+                        self.get_audio_sources()[key].parents.add(parent)
                 game_archive.audio_sources[key] = self.get_audio_sources()[key]
             else:
                 self.audio_count[key] = 1

--- a/wwise_hierarchy.py
+++ b/wwise_hierarchy.py
@@ -120,9 +120,8 @@ class HircEntry:
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
         if entry:
             for value in self.import_values:
                 setattr(self, value, getattr(entry, value))
@@ -148,9 +147,8 @@ class HircEntry:
             self.modified = False
             if self.parent:
                 self.parent.lower_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.lower_modified()
+            for bank in self.soundbanks:
+                bank.lower_modified()
         
     def import_entry(self, new_entry):
         if (
@@ -172,9 +170,8 @@ class HircEntry:
         self.modified_children+=1
         if self.parent:
             self.parent.raise_modified()
-        else:
-            for bank in self.soundbanks:
-                bank.raise_modified()
+        for bank in self.soundbanks:
+            bank.raise_modified()
         
     def lower_modified(self):
         if self.soundbanks == []:
@@ -185,9 +182,8 @@ class HircEntry:
         self.modified_children-=1
         if self.parent:
             self.parent.lower_modified()
-        else:
-            for bank in self.soundbanks:
-                bank.lower_modified()
+        for bank in self.soundbanks:
+            bank.lower_modified()
                       
     def update_size(self):
         """
@@ -296,9 +292,8 @@ class MusicSegment(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
         if entry:
             for value in self.import_values:
                 setattr(self, value, getattr(entry, value))
@@ -452,9 +447,8 @@ class Action(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
         if entry:
             for value in self.import_values:
                 setattr(self, value, getattr(entry, value))
@@ -1696,9 +1690,8 @@ class Event(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
 
         if entry:
             for value in self.import_values:
@@ -1838,9 +1831,8 @@ class RandomSequenceContainer(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
 
         if entry:
             for value in self.import_values:
@@ -2007,9 +1999,8 @@ class Sound(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
 
         if entry:
             for value in self.import_values:
@@ -3304,9 +3295,8 @@ class LayerContainer(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
 
         if entry:
             for value in self.import_values:
@@ -3412,9 +3402,8 @@ class ActorMixer(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
 
         if entry:
             for value in self.import_values:
@@ -3642,9 +3631,8 @@ class SwitchContainer(HircEntry):
             self.data_old = self.get_data()
             if self.parent:
                 self.parent.raise_modified()
-            else:
-                for bank in self.soundbanks:
-                    bank.raise_modified()
+            for bank in self.soundbanks:
+                bank.raise_modified()
 
         if entry:
             for value in self.import_values:


### PR DESCRIPTION
- Disables hierarchy import when importing patches, only audio metadata will get imported. Can toggle back on later.
- Fixes error on applying changes to RTPC graphs
- Remove invalid assertion on number of tags on treeview entries
- Add version number to the window title
- Fix issue with incorrectly combining audio source parents
- Fix issue with shared wwise hierarchy entries causing soundbanks to be marked as modified when they shouldn't have been