### PR TITLE
Fix determining if a soundbank has been modified

### DIFF
--- a/audio_modder.py
+++ b/audio_modder.py
@@ -1503,7 +1503,7 @@ class MainWindow:
             archive = os.path.join(self.app_state.game_data_path, archive)
             self.task_manager.schedule(name=f"Loading Archive {os.path.basename(archive)}", callback=None, task=task(mod.load_archive_file), archive_file=archive)
         for file in files:
-            self.task_manager.schedule(name=f"Applying Patch {file}", callback=None, task=task(mod.import_patch), patch_file=file, import_hierarchy=False)
+            self.task_manager.schedule(name=f"Applying Patch {file}", callback=None, task=task(mod.import_patch), patch_file=file)
         self.task_manager.schedule(name="Saving Output File", callback=None, task=self.combine_mods_write_output, mod=mod)
         
     @task    
@@ -2479,7 +2479,7 @@ class MainWindow:
         for archive in archives:
             archive = os.path.join(self.app_state.game_data_path, archive)
             self.task_manager.schedule(name=f"Loading Archive {os.path.basename(archive)}", callback=self.import_patch_load_archive_finished, task=self.load_archive_task, archive_files=[archive])
-        self.task_manager.schedule(name="Applying Patch", callback=self.import_patch_finished, task=task(self.mod_handler.get_active_mod().import_patch), patch_file=patch_file, import_hierarchy=False)
+        self.task_manager.schedule(name="Applying Patch", callback=self.import_patch_finished, task=task(self.mod_handler.get_active_mod().import_patch), patch_file=patch_file)
         
     @callback
     def import_patch_load_archive_finished(self, results):

--- a/core.py
+++ b/core.py
@@ -43,6 +43,9 @@ class AudioSource:
             for item in self.parents:
                 if not self.modified:
                     item.raise_modified()
+                    if isinstance(item, HircEntry):
+                        for bank in item.soundbanks:
+                            bank.raise_modified()
         if set_modified:
             self.modified = True
             
@@ -77,6 +80,9 @@ class AudioSource:
             if notify_subscribers:
                 for item in self.parents:
                     item.lower_modified()
+                    if isinstance(item, HircEntry):
+                        for bank in item.soundbanks:
+                            bank.lower_modified()
                 
 
 class TocHeader:

--- a/wwise_hierarchy.py
+++ b/wwise_hierarchy.py
@@ -170,8 +170,6 @@ class HircEntry:
         self.modified_children+=1
         if self.parent:
             self.parent.raise_modified()
-        for bank in self.soundbanks:
-            bank.raise_modified()
         
     def lower_modified(self):
         if self.soundbanks == []:

--- a/wwise_hierarchy.py
+++ b/wwise_hierarchy.py
@@ -2106,10 +2106,11 @@ class WwiseHierarchy:
                 
     def import_hierarchy(self, new_hierarchy: 'WwiseHierarchy'):
         for entry in new_hierarchy.get_entries():
-            if entry.hierarchy_id in self.entries:
-                self.entries[entry.hierarchy_id].import_entry(entry)
-            else:
-                self.add_entry(entry)
+            if isinstance(entry, (MusicSegment, MusicTrack)):
+                if entry.hierarchy_id in self.entries:
+                    self.entries[entry.hierarchy_id].import_entry(entry)
+                else:
+                    self.add_entry(entry)
                 
     def revert_modifications(self, entry_id: int = 0):
         assert_not_none(f"No WwiseBank is attached to entry {self.soundbank}", self.soundbank)


### PR DESCRIPTION
Move marking soundbanks modified out of the raise_modified() function. It now only happens in set_data() for either a HircEntry or an AudioSource.