### PR TITLE
Parse filename for audio ID with sequence number prefix

### DIFF
--- a/audio_modder.py
+++ b/audio_modder.py
@@ -1617,7 +1617,7 @@ class MainWindow:
                 and self.treeview.item(event.widget.identify_row(event.y_root - self.treeview.winfo_rooty()), option="values")
                 and self.treeview.item(event.widget.identify_row(event.y_root - self.treeview.winfo_rooty()), option="values")[0] == "Audio Source"
             ):
-                audio_id = get_number_prefix(os.path.basename(import_files[0]))
+                audio_id = parse_filename(os.path.basename(import_files[0]))
                 if audio_id != 0 and self.mod_handler.get_active_mod().get_audio_source(audio_id) is not None:
                     answer = askyesnocancel(title="Import", message="There is a file with the same name, would you like to replace that instead?")
                     if answer is None:
@@ -1630,7 +1630,7 @@ class MainWindow:
                     targets = [int(self.treeview.item(event.widget.identify_row(event.y_root - self.treeview.winfo_rooty()), option='tags')[0])]
                 file_dict = {import_files[0]: targets}
             else:
-                file_dict = {file: [get_number_prefix(os.path.basename(file))] for file in import_files}
+                file_dict = {file: [parse_filename(os.path.basename(file))] for file in import_files}
             self.import_files(file_dict)
 
     def drop_add_to_workspace(self, event):
@@ -1798,7 +1798,7 @@ class MainWindow:
                 return
             elif tags[0] == "dir":
                 return
-        file_dict = {self.workspace.item(i, option="values")[0]: [get_number_prefix(os.path.basename(self.workspace.item(i, option="values")[0]))] for i in selects if self.workspace.item(i, option="tags")[0] == "file"} 
+        file_dict = {self.workspace.item(i, option="values")[0]: [parse_filename(os.path.basename(self.workspace.item(i, option="values")[0]))] for i in selects if self.workspace.item(i, option="tags")[0] == "file"} 
         self.workspace_popup_menu.add_command(
             label="Import", 
             command=lambda: self.import_files(file_dict)
@@ -1815,7 +1815,7 @@ class MainWindow:
         files = filedialog.askopenfilenames(title="Choose files to import", filetypes=available_filetypes)
         if not files:
             return
-        file_dict = {file: [get_number_prefix(os.path.basename(file))] for file in files}
+        file_dict = {file: [parse_filename(os.path.basename(file))] for file in files}
         self.import_files(file_dict)
         
     def import_files(self, file_dict):

--- a/util.py
+++ b/util.py
@@ -130,6 +130,32 @@ def get_number_prefix(n: str):
         return int(number)
     except:
         return 0
+        
+def is_integer(n: str):
+    try:
+        _ = int(n)
+        return True
+    except:
+        return False
+        
+def parse_filename(name: str):
+    '''
+    Options:
+    id_fluff.wav
+    seq_id_fluff.wav
+    *fluff may or may not be separated by an underscore
+    *sequence number will always be separated by an underscore
+    '''
+    id_number = 0
+    parts = name.split("_")
+    if len(parts) > 1:
+        if is_integer(parts[0]) and get_number_prefix(parts[1]) != 0:
+            id_number = get_number_prefix(parts[1])
+        else:
+            id_number = get_number_prefix(parts[0])
+    else:
+        id_number = get_number_prefix(parts[0])
+    return id_number
 
 def murmur64_hash(data: Any, seed: int = 0):
 


### PR DESCRIPTION
- Allows for parsing sequence numbers properly when importing files. Filenames such as 5_5799129445_extra_title.wav should work properly
- NEW REQUIREMENT: CANNOT NAME FILE (audio_id)_(number)morestuff.wav such as 43892292_1_hello.wav or it will think the 1 is the audio id and 12345 is the sequence number. Seems unlikely anyone has named files in such a way, but it will break if they did